### PR TITLE
Modified SEP to use a safe URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,4 @@ pygments: true
 category-list: [features]
 permalink: pretty
 baseurl: //www.mybb.com
+safebaseurl: www.mybb.com

--- a/support/eligibility-policy.html
+++ b/support/eligibility-policy.html
@@ -41,15 +41,15 @@ description: The MyBB group is not obligated to provide support to users, howeve
 			To receive support users must display at the very least the following "powered by" notice on every page of their forum:
 		</p>
 		<blockquote>
-			Powered by <a rel="nofollow" class="external text" href="{{ site.baseurl }}">MyBB</a>.
+			Powered by <a rel="nofollow" class="external text" href="{{ site.safebaseurl }}">MyBB</a>.
 		</blockquote>
 		<p>
-			The text must contain a link to <a rel="nofollow" href="{{ site.baseurl }}">{{ site.baseurl }}</a>, an image of the text is acceptable however it must still link to <a rel="nofollow" href="{{ site.baseurl }}">{{ site.baseurl }}</a>.
+			The text must contain a link to <a rel="nofollow" href="{{ site.safebaseurl }}">{{ site.safebaseurl }}</a>, an image of the text is acceptable however it must still link to <a rel="nofollow" href="{{ site.baseurl }}">{{ site.baseurl }}</a>.
 		</p>
 		<p>
 			If your theme does not already carry the powered by message it can be added by going into your admin control panel &gt; Templates &amp; Styles &gt; Templates &gt; *Select template* &gt; Footer templates &gt; Footer and then adding the following code:
 		</p>
-			<pre>Powered by &lt;a href=&quot;{{ site.baseurl }}&quot; target=&quot;_blank&quot;&gt;MyBB&lt;/a&gt;.</pre>
+			<pre>Powered by &lt;a href=&quot;{{ site.safebaseurl }}&quot; target=&quot;_blank&quot;&gt;MyBB&lt;/a&gt;.</pre>
 		<p>
 			Users that are found to violate this rule will be denied support temporarily (for the first offense) until rectified, or permanently for repeated offenders.
 		</p>


### PR DESCRIPTION
The SEP page uses baseurl currently, which starts with //. To avoid breaking stuff, I added a new key to _config.yml, "safebaseurl" and updated the SEP page accordingly.
