### PR TITLE
Base URL protocols

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,5 +3,5 @@ markdown: kramdown
 pygments: true
 category-list: [features]
 permalink: pretty
-baseurl: //www.mybb.com
-safebaseurl: www.mybb.com
+baseurl: https://www.mybb.com
+safebaseurl: https://www.mybb.com


### PR DESCRIPTION
#22 should have been `safebaseurl: https://www.mybb.com` as now on the [Support Eligibility](https://www.mybb.com/support/eligibility-policy/) page the link is interpreted by browsers as `https://www.mybb.com/support/eligibility-policy/www.mybb.com` (not good :sob:)...

`baseurl` may as well be HTTPS now since you are forced onto the HTTPS protocol when browsing the website.
