### PR TITLE
Fixes #76 Show notice if no upgrade needed in Release Notes

### DIFF
--- a/_layouts/version.html
+++ b/_layouts/version.html
@@ -109,12 +109,12 @@ layout: default
 {% if page.upgrade_script_required %}
     <div class="note note--upgradeScriptRequired">
         <i class="fa fa-fw fa-cogs"></i>
-        <p>Running the <strong>upgrade script</strong> is required.</p>
+        <p>Running the upgrade script is <strong>required</strong> when upgrading to this release.</p>
     </div>
 {% else %}
     <div class="note">
         <i class="fa fa-fw fa-cogs"></i>
-        <p>This release does <strong>not</strong> need running the upgrade script.</p>
+        <p>The upgrade script does <strong>not</strong> need to be run when upgrading to this release with the Changed Files package.</p>
     </div>
 {% endif %}
 


### PR DESCRIPTION
Fixes #76

Wording for not requiring upgrade script isn't grammatically correct.

Brings formatting inline with both notices.