### PR TITLE
Update OpenBSD donation option

### DIFF
--- a/about/donations.html
+++ b/about/donations.html
@@ -36,9 +36,9 @@ description: Help maintain the MyBB Project by donating money for servers, domai
                 <p><a href="https://supporters.eff.org/donate"><strong>Donate to the EFF &rarr;</strong></a></p>
             </li>
             <li>
-                <h2>OpenBSD</h2>
-                <p>The OpenBSD project produces a free operating system emphasizing quality, portability and security. MyBB relies on sustained compatibility and standardization in the web stack environment.</p>
-                <p><a href="https://www.openbsd.org/donations.html"><strong>Donate to OpenBSD &rarr;</strong></a></p>
+                <h2>The OpenBSD Foundation</h2>
+                <p>The OpenBSD Foundation is a Canadian not-for-profit corporation which exists to support OpenBSD and related projects such as OpenSSH, OpenBGPD, OpenNTPD, OpenSMTPD and LibreSSL. MyBB and the web rely on the software supported by the foundation and its continued maintenance.</p>
+                <p><a href="http://www.openbsdfoundation.org/donations.html"><strong>Donate to OpenBSD &rarr;</strong></a></p>
             </li>
 	</section>
 </div>


### PR DESCRIPTION
Point to the OpenBSD FOundation rather than simply the OpenBSD project. The Foundation support OpenBSD itself, OpenSSH, OpenNTPD, LibreSSL and other tools in heavy use around the web.