### PR TITLE
Remove dragonexpert from support team page

### DIFF
--- a/_data/team_support.yml
+++ b/_data/team_support.yml
@@ -3,5 +3,3 @@
 - username: "katos"
   uid: 104958
   name: "Phil Marsh"
-- username: "dragonexpert"
-  uid: 24419


### PR DESCRIPTION
This PR removes dragonexpert from the support team data YAML file.

Fixes #84.