### PR TITLE
Remove Matslom from development team

### DIFF
--- a/_data/team_development.yml
+++ b/_data/team_development.yml
@@ -37,14 +37,6 @@
   pgp_link: "https://keybase.io/mattrogowski/key.asc"
 - username: "Wildcard"
   uid: 55383
-- username: "Matslom"
-  uid: 69440
-  github: "Matslom"
-  twitter: "Matslom"
-  website: "http://matslom.pl"
-  keybase: "matslom"
-  pgp_fingerprint: "EE1A EF3A A53B B082 B8A4 6C93 7C5B B98A 936D F4DE"
-  pgp_link: "https://keybase.io/matslom/key.asc"
 - username: "Eric J"
   uid: 13376
   github: "Eric-Jackson"


### PR DESCRIPTION
Matslom has left the MyBB team as of today unfortunately, this PR removes him from the website.