### PR TITLE
Fix EOL notices not being shown on some older releases

### DIFF
--- a/_data/eol_versions.yml
+++ b/_data/eol_versions.yml
@@ -1,4 +1,9 @@
+- series: "RC"
+  codes: ["DevBB", "Beta4", "RC1", "RC2", "RC3", "RC4"]
+- series: "PR"
+  codes: ["PR1", "PR2"]
 - series: "1.0"
+  codes: ["100", "101", "102", "103", "104"]
 - series: "1.1"
 - series: "1.2"
   text: "The MyBB 1.2 series reached end of life on June 1, 2009."

--- a/_layouts/version.html
+++ b/_layouts/version.html
@@ -61,7 +61,9 @@ section: download
 
                     {% assign matchedSeries = true %}
 
-                    {% if eolSeriesSize > versionSeriesSize %}
+                    {% if eol.codes and eol.codes contains page.version_code %}
+                        {% assign matchedSeries = true %}
+                    {% elsif eolSeriesSize > versionSeriesSize %}
                         {% assign matchedSeries = false %}
                     {% else %}
                         {% for part in eolSeries %}
@@ -83,11 +85,11 @@ section: download
                                     This means there will be no more security or maintenance releases for this series and forums running this version of MyBB may be at risk of unfixed security issues. <strong>The MyBB Group strongly encourages all communities to upgrade to the latest release of MyBB as soon as possible.</strong>
                                 </p>
                                 <div class="release-notes__note__buttons">
-                                    <a href="{{ site.baseurl }}/download/" class="button button--big">
+                                    <a href="{{ site.baseurl }}/download/" class="button button--medium">
                                         {% include icon.html icon="download" %} Download latest
                                     </a>
                                     {% if eol.link %}
-                                        <a href="{{ eol.link }}" class="button button--big button--secondary button--default-background-border">
+                                        <a href="{{ eol.link }}" class="button button--medium button--secondary button--default-background-border">
                                             {% include icon.html icon="info-circle" %} Find out more
                                         </a>
                                     {% endif %}


### PR DESCRIPTION
Notices weren't being shown for 1.01 etc because of the different version number formatting. So added another method to assign the releases to an EOL series using a list of version codes.

Also reduced size of the buttons because they were pretty oversized!