### PR TITLE
Re-add IRC

### DIFF
--- a/about/ecosystem.html
+++ b/about/ecosystem.html
@@ -94,6 +94,14 @@ meta_description: Platforms and services used by MyBB.
 		</div>
 		<div class="simple-table">
 			<div class="simple-table__heading">
+				IRC
+			</div>
+			<div class="simple-table__content">
+				<p>We operate an <strong>IRC</strong> channel <a href="ircs://irc.libera.chat/mybb">#mybb on libera.chat</a> as an alternative way to connect with our users and provide a place for MyBB-related discussions.</p>
+			</div>
+		</div>
+		<div class="simple-table">
+			<div class="simple-table__heading">
 				<a href="https://keybase.io"><img src="{{ site.baseurl }}/assets/images/products/keybase.png" /></a>
 			</div>
 			<div class="simple-table__content">


### PR DESCRIPTION
Adding IRC back as a communication platform after setting up a project and channel on libera.chat. This provides an alternative to Discord.