### PR TITLE
Add children abuse material to the Support Eligibility policy

### DIFF
--- a/support/eligibility-policy.html
+++ b/support/eligibility-policy.html
@@ -80,7 +80,11 @@ redirect_from:
 			</tr>
 			<tr>
 				<td>Danger to privacy/safety/security</td>
-				<td>Content on forum may pose a danger to privacy, safety, or security of others</td>
+				<td>Forum contains content that may pose a danger to privacy, safety, or security of others</td>
+			</tr>
+			<tr>
+				<td>Children abuse related material</td>
+				<td>Forum contains children abuse or children sexual abuse material, as well as children content in a serialized manner</td>
 			</tr>
 		</table>
 	</section>

--- a/support/eligibility-policy.html
+++ b/support/eligibility-policy.html
@@ -83,8 +83,8 @@ redirect_from:
 				<td>Forum contains content that may pose a danger to privacy, safety, or security of others</td>
 			</tr>
 			<tr>
-				<td>Children abuse related material</td>
-				<td>Forum contains children abuse or children sexual abuse material, as well as children content in a sexualized manner</td>
+				<td>Child abuse related material</td>
+				<td>Forum contains child abuse or child sexual abuse material, as well as child content in a sexualized manner</td>
 			</tr>
 		</table>
 	</section>

--- a/support/eligibility-policy.html
+++ b/support/eligibility-policy.html
@@ -84,7 +84,7 @@ redirect_from:
 			</tr>
 			<tr>
 				<td>Children abuse related material</td>
-				<td>Forum contains children abuse or children sexual abuse material, as well as children content in a serialized manner</td>
+				<td>Forum contains children abuse or children sexual abuse material, as well as children content in a sexualized manner</td>
 			</tr>
 		</table>
 	</section>


### PR DESCRIPTION
Children abuse or children sexual abuse material, as well as children content in a sexualized manner (i.e: sharing pictures of children for visual gratification) are serious issues.

Because of this, this proposal suggests explicitly denying support to users for content they host in any of their forums or sites related to these.

Feedback is welcome.

Regards.
